### PR TITLE
chore: Dump dogstatsd version to the newest version

### DIFF
--- a/lib/rack/dogstatsd.rb
+++ b/lib/rack/dogstatsd.rb
@@ -1,4 +1,4 @@
-require 'statsd'
+require 'datadog/statsd'
 
 module Rack
   class DogStatsd
@@ -8,7 +8,7 @@ module Rack
 
       host = options[:host] || 'localhost'
       port = options[:port] || 8125
-      @statsd = options[:statsd] || Statsd.new(host, port, **options)
+      @statsd = options[:statsd] || Datadog::Statsd.new(host, port, **options)
       @metric = options[:metric] || 'rack-dogstatsd.response.time'
     end
 

--- a/lib/rack/dogstatsd.rb
+++ b/lib/rack/dogstatsd.rb
@@ -6,8 +6,8 @@ module Rack
     def initialize(app, options = {})
       @app = app
 
-      host = options[:host] || 'localhost'
-      port = options[:port] || 8125
+      host = options[:host]
+      port = options[:port]
       @statsd = options[:statsd] || Datadog::Statsd.new(host, port, **options)
       @metric = options[:metric] || 'rack-dogstatsd.response.time'
     end

--- a/rack-dogstatsd.gemspec
+++ b/rack-dogstatsd.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'dogstatsd-ruby', '~> 1.5', '>= 1.5.0'
+  spec.add_runtime_dependency 'dogstatsd-ruby', '~> 4', '>= 4.8.1'
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/rack-dogstatsd.gemspec
+++ b/rack-dogstatsd.gemspec
@@ -6,12 +6,12 @@ require 'rack/dogstatsd/version'
 Gem::Specification.new do |spec|
   spec.name          = "rack-dogstatsd"
   spec.version       = Rack::DogStatsd::VERSION
-  spec.authors       = ["James Bowes"]
-  spec.email         = ["jbowes@repl.ca"]
+  spec.authors       = ["James Bowes", "Pieter Mulder"]
+  spec.email         = ["jbowes@repl.ca", "pieter.mulder@wooga.net"]
 
   spec.summary       = %q{Rack middleware for dogstatsd}
   spec.description   = %q{Rack middleware for dogstatsd}
-  spec.homepage      = "https://github.com/jbowes/rack-dogstatsd"
+  spec.homepage      = "https://github.com/wooga/rack-dogstatsd"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
This allows using features like setting the `DD_ENTITY_ID` variable to get the right k8s pod metadata.